### PR TITLE
Ep 34 publish package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This is the component library used by EdgarPro to maintain a uniform experience 
 ## Installation
 
 ```zsh
-pnpm install @edgarpro/library@latest
+pnpm install @johnhodge/library@latest
 ```
 
 ```zsh
-npm install @edgarpro/library@latest
+npm install @johnhodge/library@latest
 ```
 
 ## Included
@@ -52,7 +52,7 @@ const config: Config = {
 
     //⬇ Add this line after the default items to tell Tailwind to include classes used in this library ⬇ 
 
-    './node_modules/@edgarpro/**/*.{js,ts,jsx,tsx,mdx}',
+    './node_modules/@johnhodge/**/*.{js,ts,jsx,tsx,mdx}',
   ],
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,11 +12,15 @@
   },
   "main": "./src/app/components/index.js",
   "types": "./src/app/components/index.d.ts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": false,
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/johnhodge/ep_library"
   },
   "scripts": {
     "tsc": "tsc --declaration --sourceMap --jsx react --esModuleInterop --lib es2021.string",


### PR DESCRIPTION
In this PR, I updated the package information and moved the registry to github. I was able to import the packages as usual, but deploying through a 401 error: https://vercel.com/johnhodge/gh-npm-registry-test/Hha5aUmP8KNsireMbcQLuCAe7kix

I'm pushing this commit up as a checkpoint and will keep looking into the issue more.