### PR TITLE
EP-81 make anchors link to hp

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://www.johnhodge.com"
   },
   "main": "./src/app/components/index.js",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/src/app/components/link.js
+++ b/src/app/components/link.js
@@ -10,10 +10,10 @@ function GlobalLink(props) {
     var defaultclassName = 'text-secondary-600 no-underline md:hover:underline';
     var className = (0, tailwind_merge_1.twMerge)(defaultclassName, props.className);
     if (props.type != 'external') {
-        return (react_1.default.createElement(link_1.default, { href: !props.pageAnchor ? props.href : "#".concat(props.href), title: props.title, "aria-label": props.title, className: className, target: '_self' }, props.children));
+        return (react_1.default.createElement(link_1.default, { href: !props.pageAnchor ? props.href : "/#".concat(props.href), title: props.title, "aria-label": props.title, className: className, target: '_self' }, props.children));
     }
     else {
-        return (react_1.default.createElement(link_1.default, { href: !props.pageAnchor ? props.href : "#".concat(props.href), title: props.title, className: className, target: '_blank', referrerPolicy: 'no-referrer', rel: 'noopener noreferrer' }, props.children));
+        return (react_1.default.createElement(link_1.default, { href: !props.pageAnchor ? props.href : "/#".concat(props.href), title: props.title, className: className, target: '_blank', referrerPolicy: 'no-referrer', rel: 'noopener noreferrer' }, props.children));
     }
 }
 exports.default = GlobalLink;

--- a/src/app/components/link.tsx
+++ b/src/app/components/link.tsx
@@ -9,7 +9,7 @@ export default function GlobalLink(props: LinkData) {
   if (props.type != 'external') {
     return (
       <Link
-        href={!props.pageAnchor ? props.href : `#${props.href}`}
+        href={!props.pageAnchor ? props.href : `/#${props.href}`}
         title={props.title}
         aria-label={props.title}
         className={className}
@@ -20,7 +20,7 @@ export default function GlobalLink(props: LinkData) {
   } else {
     return (
       <Link
-        href={!props.pageAnchor ? props.href : `#${props.href}`}
+        href={!props.pageAnchor ? props.href : `/#${props.href}`}
         title={props.title}
         className={className}
         target='_blank'

--- a/src/app/sub-page/page.tsx
+++ b/src/app/sub-page/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Hello world</h1>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2015",
-    "lib": ["ES2021", "dom", "dom.iterable", "esnext"],
+    "lib": [
+      "ES2021",
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +24,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
In this PR I updated the link component to link anchors on the homepage only, not subpages. 

I know this will create other issues at some point, and before we reach that point, we need to build out the website to have subpages instead of anchors on the main homepage. Each product feature, or value props, should be described on its own page. Once we're using subpages our navigation, we can remove this update and use anchors to link to a specific location on any page, not just the hp.