### PR TITLE
Ep 84 broken library href

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://www.johnhodge.com"
   },
   "main": "./src/app/components/index.js",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "private": false,
   "publishConfig": {
     "access": "public",

--- a/src/app/components/button.js
+++ b/src/app/components/button.js
@@ -22,7 +22,7 @@ function GlobalButton(props) {
     var defaultClassname = 'not-prose flex flex-row items-center gap-2 w-fit px-4 py-2 rounded-lg border font-semibold';
     var classNames = (0, tailwind_merge_1.twMerge)(defaultClassname, colors[props.theme], props.className);
     if (props.eventType === 'link') {
-        return (react_1.default.createElement(link_1.default, { className: classNames, href: props.href, title: props.title, type: props.type },
+        return (react_1.default.createElement(link_1.default, { className: classNames, href: props.href, title: props.title, type: props.type, pageAnchor: props.pageAnchor },
             react_1.default.createElement("span", null, props.children),
             props.icon ? react_1.default.createElement("span", null, icon[props.icon]) : ''));
     }

--- a/src/app/components/button.tsx
+++ b/src/app/components/button.tsx
@@ -35,7 +35,8 @@ export default function GlobalButton(props: GlobalButtonData) {
         className={classNames}
         href={props.href}
         title={props.title}
-        type={props.type}>
+        type={props.type}
+        pageAnchor={props.pageAnchor}>
         <span>{props.children}</span>
         {props.icon ? <span>{icon[props.icon]}</span> : ''}
       </GlobalLink>

--- a/src/app/components/link.js
+++ b/src/app/components/link.js
@@ -10,10 +10,10 @@ function GlobalLink(props) {
     var defaultclassName = 'text-secondary-600 no-underline md:hover:underline';
     var className = (0, tailwind_merge_1.twMerge)(defaultclassName, props.className);
     if (props.type != 'external') {
-        return (react_1.default.createElement(link_1.default, { href: !props.pageAnchor ? "/".concat(props.href) : "/#".concat(props.href), title: props.title, "aria-label": props.title, className: className, target: '_self' }, props.children));
+        return (react_1.default.createElement(link_1.default, { href: props.href, title: props.title, "aria-label": props.title, className: className, target: '_self' }, props.children));
     }
     else {
-        return (react_1.default.createElement(link_1.default, { href: !props.pageAnchor ? "/".concat(props.href) : "/#".concat(props.href), title: props.title, className: className, target: '_blank', referrerPolicy: 'no-referrer', rel: 'noopener noreferrer' }, props.children));
+        return (react_1.default.createElement(link_1.default, { href: props.href, title: props.title, className: className, target: '_blank', referrerPolicy: 'no-referrer', rel: 'noopener noreferrer' }, props.children));
     }
 }
 exports.default = GlobalLink;

--- a/src/app/components/link.tsx
+++ b/src/app/components/link.tsx
@@ -9,7 +9,7 @@ export default function GlobalLink(props: LinkData) {
   if (props.type != 'external') {
     return (
       <Link
-        href={!props.pageAnchor ? `/${props.href}` : `/#${props.href}`}
+        href={props.href}
         title={props.title}
         aria-label={props.title}
         className={className}
@@ -20,7 +20,7 @@ export default function GlobalLink(props: LinkData) {
   } else {
     return (
       <Link
-        href={!props.pageAnchor ? `/${props.href}` : `/#${props.href}`}
+        href={props.href}
         title={props.title}
         className={className}
         target='_blank'

--- a/src/app/components/nav.js
+++ b/src/app/components/nav.js
@@ -79,8 +79,12 @@ function NavItems(props) {
     else {
         return (react_1.default.createElement(react_1.default.Fragment, null, props.navItems.map(function (item) {
             return !props.mobile ? (react_1.default.createElement("li", { key: "".concat(item.name.toLowerCase().replaceAll(' ', '-'), "_").concat(item.sys.id) },
-                react_1.default.createElement(link_1.default, { href: "".concat(item.name.toLowerCase().replaceAll(' ', '-')), title: item.name, type: 'internal', className: className, pageAnchor: item.pageAnchor }, item.name))) : (react_1.default.createElement("li", { key: "".concat(item.name.toLowerCase().replaceAll(' ', '-'), "_").concat(item.sys.id), onClick: handleClick },
-                react_1.default.createElement(link_1.default, { href: "".concat(item.name.toLowerCase().replaceAll(' ', '-')), title: item.name, type: 'internal', className: className, pageAnchor: item.pageAnchor }, item.name)));
+                react_1.default.createElement(link_1.default, { href: "".concat(item.pageAnchor ? '/#' : '/').concat(item.name
+                        .toLowerCase()
+                        .replaceAll(' ', '-')), title: item.name, type: 'internal', className: className, pageAnchor: item.pageAnchor }, item.name))) : (react_1.default.createElement("li", { key: "".concat(item.name.toLowerCase().replaceAll(' ', '-'), "_").concat(item.sys.id), onClick: handleClick },
+                react_1.default.createElement(link_1.default, { href: "".concat(item.pageAnchor ? '/#' : '/').concat(item.name
+                        .toLowerCase()
+                        .replaceAll(' ', '-')), title: item.name, type: 'internal', className: className, pageAnchor: item.pageAnchor }, item.name)));
         })));
     }
 }

--- a/src/app/components/nav.tsx
+++ b/src/app/components/nav.tsx
@@ -105,7 +105,9 @@ export function NavItems(props: NavItemsPropData) {
                 item.sys.id
               }`}>
               <GlobalLink
-                href={`${item.name.toLowerCase().replaceAll(' ', '-')}`}
+                href={`${item.pageAnchor ? '/#' : '/'}${item.name
+                  .toLowerCase()
+                  .replaceAll(' ', '-')}`}
                 title={item.name}
                 type='internal'
                 className={className}
@@ -120,7 +122,9 @@ export function NavItems(props: NavItemsPropData) {
               }`}
               onClick={handleClick}>
               <GlobalLink
-                href={`${item.name.toLowerCase().replaceAll(' ', '-')}`}
+                href={`${item.pageAnchor ? '/#' : '/'}${item.name
+                  .toLowerCase()
+                  .replaceAll(' ', '-')}`}
                 title={item.name}
                 type='internal'
                 className={className}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { HomepageSectionEntryData } from '../types';
 import Callout from './components/callout';
 import GlobalNav from './components/nav';
-import GlobalLink from './components/link';
 
 const inter = Inter({ subsets: ['latin'], variable: '--inter' });
 const firaCode = Fira_Code({ subsets: ['latin'], variable: '--firaCode' });
@@ -22,7 +21,7 @@ export default async function RootLayout({
       },
       header: 'test',
       paragraph: 'test',
-      name: 'test',
+      name: 'Page Anchor',
       order: 1,
       entryType: 'product',
       pageAnchor: true,
@@ -34,7 +33,7 @@ export default async function RootLayout({
       },
       header: 'sub-page',
       paragraph: 'sub-page',
-      name: 'sub-page',
+      name: 'Sub Page',
       order: 1,
       entryType: 'product',
       pageAnchor: false,

--- a/src/app/local-components/button-section.tsx
+++ b/src/app/local-components/button-section.tsx
@@ -74,7 +74,7 @@ export default function ButtonSection() {
           eventType='link'
           title='hey'
           icon='check'
-          href='/'
+          href='https://app.edgarpro.co'
           type='external'>
           Link gray
         </GlobalButton>
@@ -83,10 +83,21 @@ export default function ButtonSection() {
           eventType='link'
           title='hey'
           icon='check'
-          href='/'
+          href='https://app.edgarpro.co'
           type='external'
           ghost>
-          Link gray
+          External Link
+        </GlobalButton>
+        <GlobalButton
+          theme='gray'
+          eventType='link'
+          title='hey'
+          icon='check'
+          href='/#test-section'
+          type='internal'
+          pageAnchor
+          ghost>
+          Page Anchor
         </GlobalButton>
       </div>
     </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,9 @@
 import { Metadata } from 'next';
-import React from 'react';
 import { MetadataData } from '../types';
-import GlobalButton from './components/button';
-import GlobalStandardPage from './templates/standard-page';
 import Loading from './loading';
-import SetMetadata from './utils/meta';
 import ButtonSection from './local-components/button-section';
+import GlobalStandardPage from './templates/standard-page';
+import SetMetadata from './utils/meta';
 
 export async function generateMetadata(): Promise<Metadata> {
   const metadata: MetadataData = {
@@ -28,6 +26,9 @@ export default function Page() {
       header='EdgarPro Brand Standards'
       fallback={<Loading />}>
       <ButtonSection />
+      <div id='test-section'>
+        <h2>Hey this is a test section</h2>
+      </div>
     </GlobalStandardPage>
   );
 }

--- a/src/app/sub-page/page.tsx
+++ b/src/app/sub-page/page.tsx
@@ -1,3 +1,15 @@
+import Link from 'next/link';
+
 export default function Page() {
-  return <h1>Hello world</h1>;
+  return (
+    <>
+      <h1>Hello world</h1>{' '}
+      <p>
+        This page has a subpage{' '}
+        <Link href='/sub-page/sub-sub' title='Sub-sub Page' type='internal'>
+          here
+        </Link>
+      </p>
+    </>
+  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,4 @@
-import {
-  RedirectableProviderType,
-  BuiltInProviderType,
-} from 'next-auth/providers/index';
-import {
-  LiteralUnion,
-  SignInAuthorizationParams,
-  SignInOptions,
-  SignInResponse,
-  SignOutParams,
-  SignOutResponse,
-} from 'next-auth/react';
-import { MouseEventHandler, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 export type LinkData = {
   href: string;
@@ -84,6 +72,7 @@ export type GlobalButtonData = {
 type LinkButtonData = {
   eventType: 'link';
   href: string;
+  pageAnchor?: boolean;
   type: 'internal' | 'external';
 };
 type OnClickButtonData = {


### PR DESCRIPTION
In this PR I fixed the broken link global component being used. I removed all the logic used in the component that was changing the href value. This was adding a lot of unnecessary complexity to a system that shouldn't be handling this logic. Now the value passed to the link component in the href prop will be used as is. This means we'll need to update other systems that call this function to make sure the value being passed to the href prop will be the correct final value. I also added the pageAnchor boolean to the button link type. This will need to be used for the contact cta on the homepage.